### PR TITLE
Changes to support frontend application, version 2.

### DIFF
--- a/makefile
+++ b/makefile
@@ -34,8 +34,9 @@ endif
 
 # Unix targets compiled on both Windows/Unix
 CC     := gcc
-CFLAGS := -lm -Wno-format -Wmissing-prototypes $(CDEFS)
-WFLAGS := -lm -Wno-format -Wmissing-prototypes $(CDEFS)
+CFLAGS := -Wno-format -Wmissing-prototypes $(CDEFS)
+WFLAGS := -Wno-format -Wmissing-prototypes $(CDEFS)
+LIBS   := -lm
 
 # Windows targets compiled on Windows/Unix
 ifdef SYSTEMROOT
@@ -69,9 +70,9 @@ target: arg1 $(BIN)/$(TARGET) $(WIN)/$(WARGET)
 # Compile target
 $(BIN)/$(TARGET) $(WIN)/$(WARGET): $(CSRC) $(HSRC) makefile usage.txt version.txt
 	@if [ ! -d $(BIN) ]; then mkdir $(BIN); fi
-	$(CC) $(CFLAGS) -o $(BIN)/$(TARGET) $(CSRC)
+	$(CC) $(CFLAGS) -o $(BIN)/$(TARGET) $(CSRC) $(LIBS)
 	@if [ ! -d $(WIN) ]; then mkdir $(WIN); fi
-	$(WC) $(WFLAGS) -o $(WIN)/$(WARGET) $(WLIBS) $(CSRC);
+	$(WC) $(WFLAGS) -o $(WIN)/$(WARGET) $(WLIBS) $(CSRC) $(LIBS);
 
 # Recursive make for the arg1 subdir
 arg1:

--- a/patterns.l
+++ b/patterns.l
@@ -3,7 +3,7 @@
 * Free software, distributed under the GNU GPL v3 license
 * There is absolutely no warranty.
 *****************************************************************************/
-
+%option always-interactive
 %{
 #include <stdlib.h>
 #include "output.h"

--- a/szg.c
+++ b/szg.c
@@ -142,6 +142,7 @@ int main(int argc, char* argv[]) {
 ////////////////////////////////////////////////////////////////////////////////
 void print(void) {
   tNumDisplay(&output, print_req, prompt);
+  fflush(NULL);
   print_req = 0;
 }
 


### PR DESCRIPTION
makefile fix: libs should be placed at the end of gcc call.
^-- linking failed with gcc version 4.6.1 (Ubuntu/Linaro 4.6.1-9ubuntu3)
Flex interactive mode forced.
Buffered streams flushed after line process.
